### PR TITLE
Revamp review workflow with drag-and-drop categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-Test
+# Recipe PDF Extractor
+
+This project is a small Flask web application that lets you upload a recipe PDF, break it into readable chunks, visually organise the text, and export the curated content to a Word document.
+
+## Features
+
+- Upload any PDF that contains a recipe.
+- Automatic cleaning that removes common noise such as empty lines and page numbers.
+- Each sentence or bullet is extracted so you can drag it into the recipe category that fits best.
+- Create custom categories on the fly, and drop anything irrelevant into the **Discard** column.
+- Download the curated recipe in a standard `.docx` (Word) format.
+
+## Requirements
+
+- Python 3.11+
+- The dependencies listed in `requirements.txt`
+
+## Getting Started
+
+1. (Optional) Create and activate a virtual environment.
+2. Install the dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Run the application:
+
+   ```bash
+   flask --app app run
+   ```
+
+4. Open your browser to `http://127.0.0.1:5000/` and upload a recipe PDF.
+
+## How it works
+
+- `PyPDF2` is used to extract the text from the PDF pages.
+- Lines that only contain a page number are filtered out.
+- Continuous blank lines are collapsed and then split into sentence-sized segments.
+- The review page shows a drag-and-drop board where you can assign each segment to categories or discard it.
+- When you click **Download Word document**, the app builds a `.docx` file using `python-docx` grouped under the headings you chose.
+
+## Notes
+
+- This extractor focuses on text-based PDFs. Scanned PDFs that require OCR are not supported out of the box.
+- The automatic cleaning is intentionally conservative so that you stay in control—use the drag-and-drop step to fine-tune the final output.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import io
+import re
+from typing import Dict, List
+
+from flask import (
+    Flask,
+    flash,
+    redirect,
+    render_template,
+    request,
+    send_file,
+    session,
+    url_for,
+)
+from PyPDF2 import PdfReader
+from docx import Document
+
+
+app = Flask(__name__)
+app.secret_key = "change-me"
+
+
+DEFAULT_CATEGORIES = ["Title", "Ingredients", "Instructions", "Notes"]
+
+
+def split_into_sentences(block: str) -> List[str]:
+    """Split a block of text into smaller sentence-like chunks."""
+    bullet_pattern = re.compile(r"^([-*\u2022]\s+|\d+[).]\s+)")
+    sentence_boundary = re.compile(r"(?<=[.!?])\s+(?=[A-Z0-9])")
+
+    chunks: List[str] = []
+    buffer: List[str] = []
+
+    def flush_buffer() -> None:
+        if not buffer:
+            return
+        text = " ".join(buffer)
+        for piece in sentence_boundary.split(text):
+            piece = piece.strip()
+            if piece:
+                chunks.append(piece)
+        buffer.clear()
+
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        if bullet_pattern.match(line):
+            flush_buffer()
+            chunks.append(line)
+        else:
+            buffer.append(line)
+
+    flush_buffer()
+    return chunks
+
+
+def extract_text_segments(file_stream: io.BytesIO) -> List[str]:
+    """Extract cleaned text segments from the uploaded PDF."""
+    reader = PdfReader(file_stream)
+    segments: List[str] = []
+
+    for page in reader.pages:
+        raw_text = page.extract_text() or ""
+        if not raw_text:
+            continue
+
+        normalized = raw_text.replace("\r", "\n")
+        lines = [line.strip() for line in normalized.split("\n")]
+        cleaned_lines = []
+
+        for line in lines:
+            if not line:
+                cleaned_lines.append("")
+                continue
+
+            if re.match(r"^(page|p)\s*\d+\b", line, re.IGNORECASE):
+                continue
+            if re.match(r"^\d+$", line):
+                continue
+
+            cleaned_lines.append(line)
+
+        joined = "\n".join(cleaned_lines)
+        for block in re.split(r"\n{2,}", joined):
+            block = block.strip()
+            if block:
+                segments.extend(split_into_sentences(block))
+
+    return segments
+
+
+@app.route("/", methods=["GET"])
+def index():
+    return render_template("upload.html")
+
+
+@app.route("/extract", methods=["POST"])
+def extract():
+    uploaded = request.files.get("pdf")
+    if not uploaded or uploaded.filename == "":
+        flash("Please choose a PDF file to upload.")
+        return redirect(url_for("index"))
+
+    if not uploaded.filename.lower().endswith(".pdf"):
+        flash("Only PDF files are supported.")
+        return redirect(url_for("index"))
+
+    file_bytes = io.BytesIO(uploaded.read())
+    file_bytes.seek(0)
+
+    try:
+        segments = extract_text_segments(file_bytes)
+    except Exception:  # pragma: no cover - PyPDF2 errors bubble up rarely
+        flash("We couldn't read that PDF. Please try a different file.")
+        return redirect(url_for("index"))
+
+    if not segments:
+        flash("No readable text was found in the PDF.")
+        return redirect(url_for("index"))
+
+    session["segments"] = segments
+    session["categories"] = DEFAULT_CATEGORIES
+    return render_template(
+        "review.html",
+        segments=segments,
+        categories=DEFAULT_CATEGORIES,
+    )
+
+
+@app.route("/download", methods=["POST"])
+def download():
+    stored_segments = session.get("segments")
+    if not stored_segments:
+        flash("Please upload a PDF before requesting a download.")
+        return redirect(url_for("index"))
+
+    assignments: Dict[int, str] = {}
+    positions: Dict[int, int] = {}
+    for key, value in request.form.items():
+        if key.startswith("assignment_"):
+            try:
+                index = int(key.split("_", 1)[1])
+            except ValueError:
+                continue
+            assignments[index] = value
+        elif key.startswith("position_"):
+            try:
+                index = int(key.split("_", 1)[1])
+                positions[index] = int(value)
+            except ValueError:
+                continue
+
+    kept_assignments = {
+        idx: category
+        for idx, category in assignments.items()
+        if category not in {"discard", "unassigned"}
+    }
+
+    if not kept_assignments:
+        flash("Assign at least one sentence to a category before downloading.")
+        return render_template(
+            "review.html",
+            segments=stored_segments,
+            categories=session.get("categories", DEFAULT_CATEGORIES),
+        )
+
+    sorted_indices = sorted(
+        kept_assignments.keys(), key=lambda idx: positions.get(idx, idx)
+    )
+
+    ordered_categories: List[str] = []
+    for idx in sorted_indices:
+        category = kept_assignments[idx]
+        if category not in ordered_categories:
+            ordered_categories.append(category)
+
+    document = Document()
+    document.add_heading("Recipe", level=1)
+
+    for category in ordered_categories:
+        document.add_heading(category, level=2)
+        for idx in sorted_indices:
+            if kept_assignments[idx] == category:
+                document.add_paragraph(stored_segments[idx])
+
+    output = io.BytesIO()
+    document.save(output)
+    output.seek(0)
+
+    return send_file(
+        output,
+        as_attachment=True,
+        download_name="recipe.docx",
+        mimetype=(
+            "application/vnd.openxmlformats-officedocument."
+            "wordprocessingml.document"
+        ),
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask>=3.0.0
+PyPDF2>=3.0.0
+python-docx>=0.8.11

--- a/templates/review.html
+++ b/templates/review.html
@@ -1,0 +1,344 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Organise Recipe Text</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        background: #f6f8fb;
+        color: #1f2933;
+        min-height: 100vh;
+      }
+
+      header {
+        padding: 2rem 1.5rem 1rem;
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+
+      h1 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(1.8rem, 3vw, 2.4rem);
+      }
+
+      p.description {
+        margin: 0;
+        max-width: 680px;
+        line-height: 1.6;
+        color: #52606d;
+      }
+
+      .messages {
+        max-width: 1100px;
+        margin: 1rem auto 0;
+        padding: 1rem 1.5rem;
+        background: #fde8e8;
+        border: 1px solid #f8b4b4;
+        border-radius: 8px;
+        color: #9b1c1c;
+      }
+
+      main {
+        max-width: 1100px;
+        margin: 0 auto;
+        padding: 0 1.5rem 3rem;
+      }
+
+      .board-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+        margin-bottom: 1rem;
+      }
+
+      button,
+      .link-button {
+        border-radius: 6px;
+        border: none;
+        padding: 0.65rem 1.2rem;
+        font-size: 0.95rem;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+        font-weight: 600;
+      }
+
+      button.primary {
+        background: #2563eb;
+        color: #fff;
+        box-shadow: 0 4px 10px rgba(37, 99, 235, 0.25);
+      }
+
+      button.secondary,
+      .link-button {
+        background: #fff;
+        color: #2563eb;
+        border: 1px solid #2563eb;
+      }
+
+      button:hover,
+      .link-button:hover {
+        transform: translateY(-1px);
+      }
+
+      .link-button {
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+      }
+
+      .board {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 1rem;
+      }
+
+      .column {
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+        display: flex;
+        flex-direction: column;
+        min-height: 320px;
+      }
+
+      .column h2 {
+        margin: 0;
+        padding: 0.85rem 1rem;
+        font-size: 1.05rem;
+        color: #1f2933;
+        border-bottom: 1px solid #e4e7eb;
+      }
+
+      .dropzone {
+        flex: 1 1 auto;
+        padding: 0.75rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .dropzone.empty::before {
+        content: "Drag text here";
+        color: #9aa5b1;
+        font-size: 0.9rem;
+        border: 2px dashed #d9e2ec;
+        border-radius: 8px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 120px;
+      }
+
+      .dropzone.hover {
+        background: rgba(59, 130, 246, 0.08);
+        border-radius: 8px;
+      }
+
+      .chunk {
+        background: #f8fafc;
+        border: 1px solid #d9e2ec;
+        border-radius: 10px;
+        padding: 0.75rem 0.85rem;
+        font-size: 0.95rem;
+        line-height: 1.5;
+        cursor: grab;
+        box-shadow: 0 4px 10px rgba(15, 23, 42, 0.06);
+      }
+
+      .chunk:active {
+        cursor: grabbing;
+      }
+
+      .chunk[data-category="discard"] {
+        background: #fef2f2;
+        border-color: #fecaca;
+      }
+
+      .chunk[data-category="unassigned"] {
+        background: #eff6ff;
+        border-color: #bfdbfe;
+      }
+
+      form {
+        display: contents;
+      }
+
+      @media (max-width: 600px) {
+        .board {
+          grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Organise the recipe text</h1>
+      <p class="description">We split the PDF into smaller chunks so you can drag each sentence or bullet into the category that best fits it. Anything dropped into “Discard” will be ignored in the export.</p>
+    </header>
+
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <div class="messages">
+          <ul>
+            {% for message in messages %}
+              <li>{{ message }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    <main>
+      <div class="board-controls">
+        <button type="button" class="secondary" id="add-column">Add category</button>
+        <a class="link-button" href="{{ url_for('index') }}">Upload another PDF</a>
+      </div>
+
+      <form action="{{ url_for('download') }}" method="post" id="assignment-form">
+        <div class="board" id="board">
+          <div class="column" data-role="unassigned">
+            <h2>Unassigned</h2>
+            <div class="dropzone empty" data-category="unassigned">
+              {% for segment in segments %}
+                <div class="chunk" draggable="true" data-index="{{ loop.index0 }}" data-category="unassigned">
+                  <input type="hidden" name="assignment_{{ loop.index0 }}" value="unassigned" data-role="assignment">
+                  <input type="hidden" name="position_{{ loop.index0 }}" value="{{ loop.index0 }}" data-role="position">
+                  {{ segment }}
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+
+          {% for category in categories %}
+            <div class="column">
+              <h2>{{ category }}</h2>
+              <div class="dropzone empty" data-category="{{ category }}"></div>
+            </div>
+          {% endfor %}
+
+          <div class="column" data-role="discard">
+            <h2>Discard</h2>
+            <div class="dropzone empty" data-category="discard"></div>
+          </div>
+        </div>
+
+        <div class="board-controls" style="margin-top: 1.5rem; justify-content: flex-end;">
+          <button type="submit" class="primary">Download Word document</button>
+        </div>
+      </form>
+    </main>
+
+    <script>
+      const board = document.getElementById('board');
+      const addColumnButton = document.getElementById('add-column');
+
+      function updateEmptyStates() {
+        document.querySelectorAll('.dropzone').forEach(zone => {
+          const hasChunks = zone.querySelector('.chunk') !== null;
+          zone.classList.toggle('empty', !hasChunks);
+        });
+      }
+
+      function handleDragStart(event) {
+        event.dataTransfer.setData('text/plain', event.currentTarget.dataset.index);
+        event.dataTransfer.effectAllowed = 'move';
+        event.currentTarget.classList.add('dragging');
+      }
+
+      function handleDragEnd(event) {
+        event.currentTarget.classList.remove('dragging');
+      }
+
+      function handleDragOver(event) {
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'move';
+        event.currentTarget.classList.add('hover');
+      }
+
+      function handleDragLeave(event) {
+        event.currentTarget.classList.remove('hover');
+      }
+
+      function handleDrop(event) {
+        event.preventDefault();
+        const index = event.dataTransfer.getData('text/plain');
+        const chunk = document.querySelector(`.chunk[data-index="${index}"]`);
+        if (!chunk) {
+          return;
+        }
+
+        const dropzone = event.currentTarget;
+        dropzone.classList.remove('hover');
+        dropzone.appendChild(chunk);
+        chunk.dataset.category = dropzone.dataset.category;
+        const assignmentInput = chunk.querySelector('input[data-role="assignment"]');
+        if (assignmentInput) {
+          assignmentInput.value = dropzone.dataset.category;
+        }
+        updateEmptyStates();
+      }
+
+      function attachZoneListeners(zone) {
+        zone.addEventListener('dragover', handleDragOver);
+        zone.addEventListener('dragleave', handleDragLeave);
+        zone.addEventListener('drop', handleDrop);
+      }
+
+      function attachChunkListeners(chunk) {
+        chunk.addEventListener('dragstart', handleDragStart);
+        chunk.addEventListener('dragend', handleDragEnd);
+      }
+
+      document.querySelectorAll('.dropzone').forEach(attachZoneListeners);
+      document.querySelectorAll('.chunk').forEach(attachChunkListeners);
+
+      addColumnButton?.addEventListener('click', () => {
+        const name = window.prompt('Name for the new category?');
+        if (!name) {
+          return;
+        }
+        const trimmed = name.trim();
+        if (!trimmed) {
+          return;
+        }
+
+        const column = document.createElement('div');
+        column.className = 'column';
+
+        const heading = document.createElement('h2');
+        heading.textContent = trimmed;
+        column.appendChild(heading);
+
+        const dropzone = document.createElement('div');
+        dropzone.className = 'dropzone empty';
+        dropzone.dataset.category = trimmed;
+        attachZoneListeners(dropzone);
+        column.appendChild(dropzone);
+
+        board.insertBefore(column, board.lastElementChild);
+        updateEmptyStates();
+      });
+
+      const form = document.getElementById('assignment-form');
+
+      form?.addEventListener('submit', () => {
+        const orderedChunks = Array.from(document.querySelectorAll('.chunk'));
+        orderedChunks.forEach((chunk, order) => {
+          const positionInput = chunk.querySelector('input[data-role="position"]');
+          if (positionInput) {
+            positionInput.value = String(order);
+          }
+        });
+      });
+
+      updateEmptyStates();
+    </script>
+  </body>
+</html>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,125 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Recipe PDF Extractor</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      }
+
+      body {
+        margin: 0;
+        background: #f6f8fb;
+        color: #1f2933;
+        min-height: 100vh;
+      }
+
+      header {
+        padding: 3rem 1.5rem 1rem;
+        max-width: 720px;
+        margin: 0 auto;
+      }
+
+      header h1 {
+        margin: 0 0 0.75rem;
+        font-size: clamp(2rem, 4vw, 2.6rem);
+      }
+
+      header p {
+        margin: 0;
+        line-height: 1.6;
+        color: #52606d;
+      }
+
+      .messages {
+        max-width: 720px;
+        margin: 0 auto 1rem;
+        padding: 1rem 1.5rem;
+        background: #fde8e8;
+        border: 1px solid #f8b4b4;
+        border-radius: 8px;
+        color: #9b1c1c;
+      }
+
+      .card {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2.5rem 2rem;
+        background: #fff;
+        border-radius: 16px;
+        box-shadow: 0 18px 40px rgba(15, 23, 42, 0.12);
+      }
+
+      label {
+        display: block;
+        margin-bottom: 0.75rem;
+        font-weight: 600;
+        font-size: 1rem;
+      }
+
+      input[type="file"] {
+        display: block;
+        margin-bottom: 1.5rem;
+        font-size: 0.95rem;
+      }
+
+      button {
+        background: #2563eb;
+        border: none;
+        color: #fff;
+        padding: 0.75rem 1.5rem;
+        border-radius: 8px;
+        cursor: pointer;
+        font-size: 1rem;
+        font-weight: 600;
+        box-shadow: 0 10px 18px rgba(37, 99, 235, 0.2);
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+      }
+
+      button:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 14px 24px rgba(37, 99, 235, 0.25);
+      }
+
+      footer {
+        text-align: center;
+        margin: 3rem 0 2rem;
+        color: #9aa5b1;
+        font-size: 0.85rem;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Recipe PDF Extractor</h1>
+      <p>Upload a recipe PDF and we will split the content into tidy sentences so you can drag each one into recipe categories before exporting to Word.</p>
+    </header>
+
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <div class="messages">
+          <ul>
+            {% for message in messages %}
+              <li>{{ message }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+    {% endwith %}
+
+    <div class="card">
+      <form action="{{ url_for('extract') }}" method="post" enctype="multipart/form-data">
+        <label for="pdf">Choose a recipe PDF</label>
+        <input type="file" id="pdf" name="pdf" accept="application/pdf" required>
+        <button type="submit">Extract recipe text</button>
+      </form>
+    </div>
+
+    <footer>
+      Works best with text-based PDFs. Scanned images will need OCR first.
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- break extracted text into sentence-sized chunks using a smarter splitter that preserves bullet items
- replace the checkbox review page with a drag-and-drop board for organising sentences into recipe categories or discarding them
- refresh the upload page and documentation to describe the new categorisation workflow and styling updates

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68cc53d0c73c832fa8d866346e08f715